### PR TITLE
.github/workflows/docker: build containers for x86_64 and aarch64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,3 +41,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
nomad is trying to deploy this on a-sea-us right now, and fails because there's no image for arm
